### PR TITLE
Add reference to theory in authors section of the doc

### DIFF
--- a/README.es-AR.md
+++ b/README.es-AR.md
@@ -75,3 +75,5 @@ de las facultades de Ingeniería e Informática de la [Universidad Nacional de L
 - Juan Martín Seery
 - Santiago Adriel Fernández
 - Lorenzo Majoros
+
+Se recomienda revisar la carpeta [`docs/theory/`](https://github.com/b-Tomas/robot-kinematics/tree/main/docs/theory) con el desarrollo matemático del proyecto.


### PR DESCRIPTION
Small addition to #24 

Adds a small reference to the theory folder at the end of the doc, given that that the earlier one can easily be overlooked.